### PR TITLE
FFI bridge for wallet addition to xaero id

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2,7 +2,9 @@
 
 use std::ffi::c_char;
 
-use crate::{compressed::XaeroPublicData, identity::XaeroIdentityManager, IdentityManager, XaeroID};
+use crate::{
+    compressed::XaeroPublicData, identity::XaeroIdentityManager, IdentityManager, XaeroID,
+};
 
 // Generate new XaeroID
 #[unsafe(no_mangle)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ pub mod cache;
 pub mod circuits;
 pub mod compressed;
 pub mod domain;
-pub mod secure_id;
 mod ffi;
+pub mod secure_id;
 
 /// A zero-knowledge proof container (e.g. RISC Zero receipt or Groth16 SNARK proof).
 #[repr(C)]


### PR DESCRIPTION
FFI bridge to:
1. generate xaero id
2. get xaero id info
